### PR TITLE
Highlight place Attributes

### DIFF
--- a/sublime/technique.sublime-syntax
+++ b/sublime/technique.sublime-syntax
@@ -62,9 +62,9 @@ contexts:
               1: keyword.operator.assignment
               2: variable.parameter.technique
 
-        - match: '^\s+(?=@\w+)'
+        - match: '^\s+(?=[@^]\w+)'
           push:
-            - role
+            - attribute
 
         # procedure title if present
 
@@ -147,9 +147,9 @@ contexts:
         - match: '->'
           scope: keyword.operator.function
 
-    role:
+    attribute:
         - meta_scope: meta.trait
-        - match: '@\w+'
+        - match: '[@^]\w+'
           scope: entity.name.trait
 
         - match: '\+'

--- a/sublime/technique.tmTheme
+++ b/sublime/technique.tmTheme
@@ -189,7 +189,7 @@
         </dict>
         <dict>
             <key>name</key>
-            <string>Role Scope</string>
+            <string>Attribute Scope</string>
             <key>scope</key>
             <string>entity.name.trait</string>
             <key>settings</key>

--- a/vim/syntax/technique.vim
+++ b/vim/syntax/technique.vim
@@ -1,6 +1,6 @@
 " Vim syntax file for Technique language
 " Language: Technique
-" Maintainer: [Your Name]
+" Maintainer: Andrew Cowie
 " Latest Revision: 2025
 
 if exists("b:current_syntax")
@@ -48,8 +48,9 @@ syn match techniqueSignatureArrow "->" contained
 syn match techniqueComma "," contained
 
 " Role assignments (Attributes) - anchored at start of line
-syn match techniqueAttribute "^\s*@[a-z][a-z0-9_]*\(\s*+\s*@[a-z][a-z0-9_]*\)*" contains=techniqueRole,techniqueAttributeOperator
+syn match techniqueAttribute "^\s*[@^][a-z][a-z0-9_]*\(\s*+\s*[@^][a-z][a-z0-9_]*\)*" contains=techniqueRole,techniquePlace,techniqueAttributeOperator
 syn match techniqueRole "@[a-z][a-z0-9_]*" contained
+syn match techniquePlace "[^][a-z][a-z0-9_]*" contained
 syn match techniqueAttributeOperator "+" contained
 
 " Basic structural elements - define first as they're used everywhere  


### PR DESCRIPTION
Last but not least update Vim and Typst (well, Sublime) syntaxes so that place Attributes with the new `^` marker are supported. This was mostly in place already, just needed adding the character.